### PR TITLE
fix(IPA-1231): column Header Sort + Drag Behavior Update

### DIFF
--- a/packages/ui-library/src/components/AdvancedTable/ColumnHeader.tsx
+++ b/packages/ui-library/src/components/AdvancedTable/ColumnHeader.tsx
@@ -41,6 +41,8 @@ export function ColumnHeader<TData>({ header, pinnedStyles }: DraggableColumnHea
     <th
       ref={setNodeRef}
       style={{ ...style, ...pinnedStyles }}
+      onClick={header.column.getToggleSortingHandler()}
+      {...listeners}
       className={classnames('select-none', {
         ['with-checkbox']: header.column.id === 'select',
         ['actions-header']: header.column.id === 'actions',
@@ -49,7 +51,7 @@ export function ColumnHeader<TData>({ header, pinnedStyles }: DraggableColumnHea
       {...attributes}
     >
       <div onClick={header.column.getToggleSortingHandler()} className="flexbox align-items--center">
-        <div {...listeners}>
+        <div>
           <Text className="text-left" weight={'bold'}>
             {flexRender(header.column.columnDef.header, header.getContext())}
           </Text>


### PR DESCRIPTION
Column Header Sort + Drag Behavior Update

Sort and Drag listeners were triggered only from the inner header wrapper by text/icon.
(were attached only to the inner text container, so dragging and sorting worked primarily from the text area).

Now - The interactive area is expanded to the whole header cell.


https://github.com/user-attachments/assets/658ef8b3-67e6-4024-b37b-6c0dac2b58d7



