### PR TITLE
fix(Tooltip): resolve SSR window is not defined errors in tooltip hooks

### DIFF
--- a/packages/ui-library/src/hooks/useGetElemPositions.ts
+++ b/packages/ui-library/src/hooks/useGetElemPositions.ts
@@ -7,14 +7,19 @@ type TPositionReturnTypes = {
   y?: number;
 };
 
+const defaultPosition = {
+  left: 0,
+  top: 0,
+  bottom: 0,
+  right: 0,
+};
+
 export const useGetElemPositions = (elemRef: HTMLElement | null): TPositionReturnTypes => {
+  if (typeof window === 'undefined') {
+    return defaultPosition;
+  }
   if (!elemRef || !elemRef.getBoundingClientRect) {
-    return {
-      left: 0,
-      top: 0,
-      bottom: 0,
-      right: 0,
-    };
+    return defaultPosition;
   }
 
   const elemDimensions = elemRef.getBoundingClientRect();

--- a/packages/ui-library/src/hooks/useGetTooltipPosition.ts
+++ b/packages/ui-library/src/hooks/useGetTooltipPosition.ts
@@ -17,13 +17,16 @@ export const useGetTooltipPosition = (info: TTooltipInfo): TTooltipPosition => {
 
   // this is calculations for tooltip top/left/bottom/right positions
   const calculatedPosition = useMemo(() => {
+    const windowHeight = typeof window !== 'undefined' ? window.innerHeight : 0;
+    const windowWidth = typeof window !== 'undefined' ? window.innerWidth : 0;
+
     const hasTopSpace = tooltipHeight + GAP < top;
 
-    const hasBottomSpace = tooltipHeight + GAP < window.innerHeight - bottom;
+    const hasBottomSpace = tooltipHeight + GAP < windowHeight - bottom;
 
     const hasLeftSpace = tooltipWidth + GAP < left;
-    const hasRightSpace = tooltipWidth + GAP < window.innerWidth - left;
-    const hasMiddleRightSpace = tooltipWidth + GAP < window.innerWidth - left - itemWidth;
+    const hasRightSpace = tooltipWidth + GAP < windowWidth - left;
+    const hasMiddleRightSpace = tooltipWidth + GAP < windowWidth - left - itemWidth;
 
     if (!hasBottomSpace && !hasRightSpace && initialPosition.includes('bottom-right')) {
       return initialPosition.replace('bottom-right', 'top-left');
@@ -49,8 +52,10 @@ export const useGetTooltipPosition = (info: TTooltipInfo): TTooltipPosition => {
 
   // this is calculations for triangle position
   const finalPosition = useMemo(() => {
+    const windowWidth = typeof window !== 'undefined' ? window.innerWidth : 0;
+
     const hasLeftSpace = tooltipWidth < left + ARROW_DISTANCE + GAP;
-    const hasRightSpace = tooltipWidth + GAP < window.innerWidth - left;
+    const hasRightSpace = tooltipWidth + GAP < windowWidth - left;
 
     // in case of middle position we don't need to change triangle position
     if (calculatedPosition.includes('middle')) {
@@ -66,7 +71,7 @@ export const useGetTooltipPosition = (info: TTooltipInfo): TTooltipPosition => {
 
     if (calculatedPosition.includes('center')) {
       const hasLeftHalfSpace = tooltipWidth / 2 < left + ARROW_DISTANCE + GAP;
-      const hasRightHalfSpace = tooltipWidth / 2 + GAP < window.innerWidth - left;
+      const hasRightHalfSpace = tooltipWidth / 2 + GAP < windowWidth - left;
       if (!hasLeftHalfSpace) {
         return calculatedPosition.replace('center', 'left');
       }


### PR DESCRIPTION
# What problem am I fixing?
Tooltip hooks access browser-only APIs directly during render — 
`window.innerHeight`/`window.innerWidth` in `useGetTooltipPosition` 
and `getBoundingClientRect` in `useGetElemPositions` — causing 
`ReferenceError: window is not defined` crash on statically 
pre-rendered Next.js pages.

# What have I done to fix the problem?
Added `typeof window !== 'undefined'` guards in both hooks, 
falling back to safe default values (0) when running on the server.