### PR TITLE
fix(Button): preserve button width when isLoading is true

### DIFF
--- a/packages/ui-library/src/assets/styles/components/_button.scss
+++ b/packages/ui-library/src/assets/styles/components/_button.scss
@@ -81,6 +81,23 @@
 
   --ds-button-transition: background-color .3s linear, color .3s linear, border-color .3s linear;
 
+  position: relative;
+
+    &__loader {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+    }
+
+    &__content {
+        display: contents;
+
+        &--hidden {
+            visibility: hidden;
+        }
+    }
+
   //----------//
 
   display: inline-flex;

--- a/packages/ui-library/src/components/Button/Button.tsx
+++ b/packages/ui-library/src/components/Button/Button.tsx
@@ -54,21 +54,22 @@ export const Button = (props: TButtonPropTypes): ReactElement => {
       form={formId}
       {...rest}
     >
-      {isLoading ? (
-        <Loader size={size} type={LITE_LOADER_TYPES.indexOf(type) === -1 ? 'dark' : 'lite'} />
-      ) : (
-        <>
-          {iconProps?.Component ? (
-            <iconProps.Component
-              size={ICON_SIZE_MAPPING[size]}
-              type={ICON_TYPE_MAPPING[iconProps.type || type]}
-              className="btn__icon"
-            />
-          ) : null}
-          {/* {buttonSecondaryText ? <span className="btn__text">{buttonSecondaryText}</span> : null} */}
-          {buttonText || children ? <span className="btn__text">{buttonText || children}</span> : null}
-        </>
+      {isLoading && (
+        <div className="btn__loader">
+          <Loader size={size} type={LITE_LOADER_TYPES.indexOf(type) === -1 ? 'dark' : 'lite'} />
+        </div>
       )}
+      <span className={classnames('btn__content', { 'btn__content--hidden': isLoading })}>
+        {iconProps?.Component ? (
+          <iconProps.Component
+            size={ICON_SIZE_MAPPING[size]}
+            type={ICON_TYPE_MAPPING[iconProps.type || type]}
+            className="btn__icon"
+          />
+        ) : null}
+        {/* {buttonSecondaryText ? <span className="btn__text">{buttonSecondaryText}</span> : null} */}
+        {buttonText || children ? <span className="btn__text">{buttonText || children}</span> : null}
+      </span>
     </button>
   );
 };


### PR DESCRIPTION
# What problem am I fixing?
When `isLoading={true}`, the button replaces its children with a `<Loader />`,
causing the button to shrink to the loader's size and producing a layout shift.

# What have I done to fix the problem?
Instead of replacing children with the loader, both are rendered simultaneously.
Children are kept in the DOM with `visibility: hidden` to preserve the button's
original width, while the loader is absolutely positioned and centered on top.