### PR TITLE
fix(IPA-1231): revert fix for resizing

### DIFF
--- a/packages/ui-library/src/components/AdvancedTable/ColumnHeader.tsx
+++ b/packages/ui-library/src/components/AdvancedTable/ColumnHeader.tsx
@@ -42,7 +42,6 @@ export function ColumnHeader<TData>({ header, pinnedStyles }: DraggableColumnHea
       ref={setNodeRef}
       style={{ ...style, ...pinnedStyles }}
       onClick={header.column.getToggleSortingHandler()}
-      {...listeners}
       className={classnames('select-none', {
         ['with-checkbox']: header.column.id === 'select',
         ['actions-header']: header.column.id === 'actions',
@@ -50,8 +49,8 @@ export function ColumnHeader<TData>({ header, pinnedStyles }: DraggableColumnHea
       })}
       {...attributes}
     >
-      <div onClick={header.column.getToggleSortingHandler()} className="flexbox align-items--center">
-        <div>
+      <div className="flexbox align-items--center">
+        <div {...listeners}>
           <Text className="text-left" weight={'bold'}>
             {flexRender(header.column.columnDef.header, header.getContext())}
           </Text>


### PR DESCRIPTION
Reverted event listener changes to restore the original implementation, which resolves the resizing issue introduced in the previous update.


https://github.com/ab-ui-tools/ab-ui-tools/pull/50/changes#diff-76df6f3e9b9cdabb22cbbde3e9dd5e35283241fc22a2be3846d2e95d7c16ca31 





