### PR TITLE
fix: sync external value prop to internal otp state

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,10 @@
 
   "eslint.nodePath": "node_modules",
 
+  "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": "explicit"
+    },
+
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,10 +15,6 @@
 
   "eslint.nodePath": "node_modules",
 
-  "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": "explicit"
-    },
-
   "typescript.tsdk": "node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/packages/ui-library/src/components/OneTimePassword/OneTimePassword.tsx
+++ b/packages/ui-library/src/components/OneTimePassword/OneTimePassword.tsx
@@ -1,7 +1,13 @@
-import type { JSX, KeyboardEvent } from 'react';
-
-import { useCallback } from 'react';
-import React, { useState, useRef } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useState,
+  useRef,
+  useEffect,
+  type JSX,
+  type KeyboardEvent,
+  type ClipboardEvent,
+} from 'react';
 import classNames from 'classnames';
 
 import type { OtpCustomProps } from './types';
@@ -15,7 +21,7 @@ import { ErrorMessage, Label } from '../../helperComponents';
 const parseValue = (value: TFormValue | undefined, count: number): string[] =>
   Array.from({ length: count }, (_, i) => (typeof value === 'string' ? value[i] : undefined) ?? '');
 
-export const OneTimePassword = React.forwardRef<HTMLInputElement, OtpCustomProps>(
+export const OneTimePassword = forwardRef<HTMLInputElement, OtpCustomProps>(
   ({
     className,
     size = 'large',
@@ -43,7 +49,7 @@ export const OneTimePassword = React.forwardRef<HTMLInputElement, OtpCustomProps
     const [otp, setOtp] = useState<string[]>(() => parseValue(value, count));
     const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
 
-    React.useEffect(() => {
+    useEffect(() => {
       setOtp(parseValue(value, count));
     }, [value, count]);
 
@@ -85,7 +91,7 @@ export const OneTimePassword = React.forwardRef<HTMLInputElement, OtpCustomProps
       }
     };
 
-    const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    const handlePaste = (e: ClipboardEvent<HTMLInputElement>) => {
       e.preventDefault();
       const pastedText = e.clipboardData.getData('text');
 

--- a/packages/ui-library/src/components/OneTimePassword/OneTimePassword.tsx
+++ b/packages/ui-library/src/components/OneTimePassword/OneTimePassword.tsx
@@ -5,12 +5,15 @@ import React, { useState, useRef } from 'react';
 import classNames from 'classnames';
 
 import type { OtpCustomProps } from './types';
-import type { TChangeEventType } from '../../types/globalTypes';
+import type { TChangeEventType, TFormValue } from '../../types/globalTypes';
 
 import { Text } from '../Text';
 import IconCheckmarkCircleFilled from '../SVGIcons/IconCheckmarkCircleFilled';
 import { Input } from '../Input';
 import { ErrorMessage, Label } from '../../helperComponents';
+
+const parseValue = (value: TFormValue | undefined, count: number): string[] =>
+  Array.from({ length: count }, (_, i) => (typeof value === 'string' ? value[i] : undefined) ?? '');
 
 export const OneTimePassword = React.forwardRef<HTMLInputElement, OtpCustomProps>(
   ({
@@ -25,6 +28,7 @@ export const OneTimePassword = React.forwardRef<HTMLInputElement, OtpCustomProps
     placeholder,
     type,
     pattern,
+    value,
     setFieldValue,
     handleChange,
     dataId = '',
@@ -36,8 +40,12 @@ export const OneTimePassword = React.forwardRef<HTMLInputElement, OtpCustomProps
     ...rest
   }): JSX.Element => {
     const isErrorVisible = hasError !== undefined ? hasError : !!error;
-    const [otp, setOtp] = useState<string[]>(Array(count).fill(''));
+    const [otp, setOtp] = useState<string[]>(() => parseValue(value, count));
     const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+    React.useEffect(() => {
+      setOtp(parseValue(value, count));
+    }, [value, count]);
 
     const onChange = (e: TChangeEventType, value: string, index: number) => {
       if (
@@ -135,6 +143,7 @@ export const OneTimePassword = React.forwardRef<HTMLInputElement, OtpCustomProps
               handleChange={(e, value) => onChange(e, value, index)}
               onKeyDown={e => handleKeyDown(e, index)}
               autoFocus={autoFocus && index === 0}
+              value={value}
               {...rest}
             />
           ))}


### PR DESCRIPTION
# What problem am I fixing?
`OneTimePassword` component was not responding to external value changes. 
Passing `value` prop or calling RHF `reset()`/`setValue()` had no effect on 
the displayed input fields because the component maintained its own internal 
`otp` state and never synced it with the incoming `value` prop.

# What have I done to fix the problem?
Added a `useEffect` that syncs the external `value` prop into the internal 
`otp` state whenever it changes. Extracted a pure `parseValue` helper that 
safely narrows `TFormValue` to `string` before splitting into individual 
characters, handling all other union type variants (`null`, `number`, etc.) 
gracefully by falling back to empty strings.