### PR TITLE
fix: Improve advanced table functionality and performance

### DIFF
--- a/packages/ui-library/src/components/AdvancedTable/AdvancedPagination.tsx
+++ b/packages/ui-library/src/components/AdvancedTable/AdvancedPagination.tsx
@@ -3,7 +3,7 @@ import type { Table } from '@tanstack/react-table';
 import { useEffect, useState } from 'react';
 import classnames from 'classnames';
 
-import type { TItemValue } from '../../types/globalTypes';
+import type { TItemValue, TSelectOptions } from '../../types/globalTypes';
 
 import { OPTIONS } from './constants';
 import { Text } from '../Text';
@@ -20,9 +20,15 @@ interface PaginationProps<T> {
   table: Table<T>;
   totalCount: number;
   buttonText?: string;
+  pageSizeOptions?: TSelectOptions;
 }
 
-export function AdvancedPagination<TData>({ table, totalCount, buttonText }: PaginationProps<TData>) {
+export function AdvancedPagination<TData>({
+  table,
+  totalCount,
+  buttonText,
+  pageSizeOptions = OPTIONS,
+}: PaginationProps<TData>) {
   const [navigatePage, setNavigatePage] = useState<string>('1');
 
   const pageIndex = table.getState().pagination.pageIndex;
@@ -82,7 +88,7 @@ export function AdvancedPagination<TData>({ table, totalCount, buttonText }: Pag
         setSelectedItem={value => onRowCountChange(value)}
         selectedItem={`${pageSize}`}
         className={'no-border'}
-        options={OPTIONS}
+        options={pageSizeOptions}
       />
       <div className={'advanced-table__pagination__right'}>
         <Text type={'tertiary'}>

--- a/packages/ui-library/src/components/AdvancedTable/ColumnHeader.tsx
+++ b/packages/ui-library/src/components/AdvancedTable/ColumnHeader.tsx
@@ -50,7 +50,7 @@ export function ColumnHeader<TData>({ header, pinnedStyles }: DraggableColumnHea
     >
       <div className="flexbox align-items--center">
         <div {...listeners}>
-          <Text className="text-left" weight={'bold'}>
+          <Text as="span" className="text-left" weight={'bold'}>
             {flexRender(header.column.columnDef.header, header.getContext())}
           </Text>
         </div>


### PR DESCRIPTION
**AdvancedPagination**
Added optional pageSizeOptions (TSelectOptions), defaulting to the existing OPTIONS constant so behavior stays the same for current callers.

**ColumnHeader**
Set Text to render as span (as="span") instead of the default p, because flexRender can output block-level content (e.g. div). Nesting div inside p is invalid HTML and caused the console warning.