### PR TITLE
Support custom data attributes for Select, Radio, and Text components

### DIFF
--- a/packages/ui-library/src/components/FormField/types.ts
+++ b/packages/ui-library/src/components/FormField/types.ts
@@ -1,8 +1,8 @@
 import type { HTMLAttributes, JSX } from 'react';
 
-import type { IFormCompProps } from '../../types/globalTypes';
+import type { IDataAttributes, IFormCompProps } from '../../types/globalTypes';
 
-export interface TFormFieldPropTypes extends HTMLAttributes<HTMLElement> {
+export interface TFormFieldPropTypes extends HTMLAttributes<HTMLElement>, IDataAttributes {
   As: (props: IFormCompProps) => JSX.Element;
   name: string;
   className?: string;

--- a/packages/ui-library/src/components/Radio/Radio.tsx
+++ b/packages/ui-library/src/components/Radio/Radio.tsx
@@ -20,6 +20,10 @@ export const Radio = forwardRef((props: TRadioProps): ReactElement | null => {
     onClick,
     dataId = '',
     iconProps,
+    onChange,
+    hasError,
+    isValid,
+    ...rest
   } = props;
   const isChecked = !!value || !!isSelected;
   const iconElement = iconProps ? iconProps : <span className="controller__icon"></span>;
@@ -38,6 +42,7 @@ export const Radio = forwardRef((props: TRadioProps): ReactElement | null => {
       className={classnames('controller', 'controller--radio', className, {
         'controller--disabled': disabled,
       })}
+      {...rest}
     >
       <input
         data-id={dataId}
@@ -46,6 +51,7 @@ export const Radio = forwardRef((props: TRadioProps): ReactElement | null => {
         onChange={changeHandler}
         checked={isSelected}
         disabled={disabled}
+        {...rest}
       />
       {iconElement}
       {label ? (

--- a/packages/ui-library/src/components/Radio/RadioGroup.tsx
+++ b/packages/ui-library/src/components/Radio/RadioGroup.tsx
@@ -23,6 +23,10 @@ export const RadioGroup = forwardRef((props: TRadioGroupProps, ref): JSX.Element
     labelAddons,
     hasError,
     selected,
+    onChange,
+    dataId,
+    isValid,
+    ...rest
   } = props;
 
   const onSelect = (selected: number | string | boolean) => {
@@ -44,6 +48,7 @@ export const RadioGroup = forwardRef((props: TRadioGroupProps, ref): JSX.Element
         },
         className
       )}
+      {...rest}
     >
       <Label
         className="radio-group__label"

--- a/packages/ui-library/src/components/Select/Select/Select.tsx
+++ b/packages/ui-library/src/components/Select/Select/Select.tsx
@@ -75,6 +75,10 @@ export const Select = (props: TSingleSelectPropTypes): JSX.Element | null => {
     renderOptions,
     isAllowed,
     defaultValue,
+    onChange,
+    error,
+    dataIdPrefix,
+    ...rest
   } = props;
 
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -278,6 +282,7 @@ export const Select = (props: TSingleSelectPropTypes): JSX.Element | null => {
         'select--opened': isOpen,
       })}
       ref={containerRef}
+      {...rest}
     >
       <Input
         onClick={disabled ? noop : onOpenOptions}

--- a/packages/ui-library/src/components/Text/types.ts
+++ b/packages/ui-library/src/components/Text/types.ts
@@ -1,5 +1,7 @@
 import type { ElementType, HTMLAttributes, MouseEvent, ReactNode } from 'react';
 
+import type { IDataAttributes } from '../../types/globalTypes';
+
 export type TTextTypes =
   | 'primary'
   | 'secondary'
@@ -24,7 +26,7 @@ export type TTextSize = 'xxsmall' | 'xsmall' | 'small' | 'standard' | 'medium' |
 export type TTextWeight = 'regular' | 'semibold' | 'bold' | 'bolder';
 export type TTextLineHeight = 'xxsmall' | 'xsmall' | 'small' | 'standard' | 'medium' | 'large';
 
-export interface TextPropTypes extends HTMLAttributes<HTMLElement> {
+export interface TextPropTypes extends HTMLAttributes<HTMLElement>, IDataAttributes {
   as?: ElementType;
   type?: TTextTypes;
   size?: TTextSize;

--- a/packages/ui-library/src/types/globalTypes.ts
+++ b/packages/ui-library/src/types/globalTypes.ts
@@ -94,7 +94,11 @@ export type TFormValue =
 
 export type TOnChange = (event: TChangeEventType) => void;
 
-export interface IFormCompProps {
+export interface IDataAttributes {
+  [key: `data-${string}`]: string | boolean | number;
+}
+
+export interface IFormCompProps extends IDataAttributes {
   hasError?: boolean;
   isValid?: boolean;
   value?: TFormValue;
@@ -102,7 +106,6 @@ export interface IFormCompProps {
   dataId?: string;
   name?: string;
   setFieldValue?: (name: string, value: TFormValue, shouldValidate?: { shouldValidate: boolean }) => void;
-  [key: `data-${string}`]: string | boolean | number;
 }
 
 export type TTooltipPosition =


### PR DESCRIPTION
This PR enables support for custom HTML5 data-* attributes across core UI components (Select, Radio, RadioGroup, Text, and FormField). This is primarily required to support UXCam data privacy masking (e.g., data-uxcam-occlude) and other third-party tracking or automated testing tools.