### PR TITLE
fix: prevent premature validation on Select option click

### DIFF
--- a/packages/ui-library/src/components/Select/Select/Select.tsx
+++ b/packages/ui-library/src/components/Select/Select/Select.tsx
@@ -311,6 +311,7 @@ export const Select = (props: TSingleSelectPropTypes): JSX.Element | null => {
       {isOpen && (
         <div
           className="select__options"
+          onMouseDown={e => e.preventDefault()}
           style={{
             left,
             width,


### PR DESCRIPTION
Problem: Clicking a dropdown option triggered validation prematurely because the blur event fired before the selection logic completed

Solution: Added onMouseDown={e => e.preventDefault()} to the options container to prevent the Input from losing focus during option selection.