### PR TITLE
fix: close nested select after clicking on input

### DIFF
--- a/packages/ui-library/src/components/Select/NestedSelect/NestedSelect.tsx
+++ b/packages/ui-library/src/components/Select/NestedSelect/NestedSelect.tsx
@@ -45,6 +45,9 @@ export const NestedSelect = (props: TNestedSelectProps): JSX.Element | null => {
     } else {
       openDropdown();
     }
+    if (isDropdownOpen) {
+      closeDropdown();
+    }
   };
 
   useOnOutsideClick(containerRef, closeDropdown, isDropdownOpen, useId());


### PR DESCRIPTION
 close nested select after clicking on input