### PR TITLE
fix: fix menu positioning

### DIFF
--- a/packages/ui-library/src/components/Menu/Menu.tsx
+++ b/packages/ui-library/src/components/Menu/Menu.tsx
@@ -1,18 +1,12 @@
 import type { ReactElement } from 'react';
 
 import ReactDOM from 'react-dom';
-import { useId, useMemo, useState } from 'react';
+import { useId, useState } from 'react';
 import classNames from 'classnames';
 
 import type { TMenuProps, TMenuItem } from './types';
 
-import {
-  useOnOutsideClick,
-  useGetElemSizes,
-  useGetTooltipPosition,
-  useGetElemPositions,
-  useHideOnScroll,
-} from '../../hooks';
+import { useOnOutsideClick, useGetMenuStyles, useHideOnScroll } from '../../hooks';
 import { OptionItem } from '../../helperComponents';
 
 export const Menu = (props: TMenuProps): ReactElement | null => {
@@ -31,33 +25,7 @@ export const Menu = (props: TMenuProps): ReactElement | null => {
   const [menuRef, setMenuRef] = useState<HTMLDivElement | null>(null);
   useOnOutsideClick([menuRef, additionalRef], onClose, isOpen, useId());
   useHideOnScroll(onClose, containerRef);
-  const { left, top } = useGetElemPositions(parentRef);
-  const { width, height } = useGetElemSizes(parentRef);
-  const { width: menuWidth, height: menuHeight } = useGetElemSizes(menuRef);
-
-  const tooltipPosition = useGetTooltipPosition({
-    tooltipRef: menuRef,
-    elemRef: parentRef,
-    initialPosition: position,
-    hasTriangle: false,
-  });
-
-  const menuStyles = useMemo(() => {
-    if (tooltipPosition === 'bottom-left') {
-      return { left: left + 4, top: top + 4 + height };
-    }
-    if (tooltipPosition === 'bottom-right') {
-      return { left: left - menuWidth + width, top: top + 4 + height };
-    }
-    if (tooltipPosition === 'top-left') {
-      return { left: left + 4, top: top - menuHeight - 4 };
-    }
-    if (tooltipPosition === 'top-right') {
-      return { left: left - menuWidth + width, top: top - menuHeight - 4 };
-    }
-
-    return { left: left, top: top + 4 + height };
-  }, [left, top, width, tooltipPosition, menuWidth, height, menuHeight]);
+  const menuStyles = useGetMenuStyles(parentRef, menuRef, position);
 
   if (!parentRef || !isOpen) {
     return null;

--- a/packages/ui-library/src/hooks/index.ts
+++ b/packages/ui-library/src/hooks/index.ts
@@ -13,3 +13,4 @@ export * from './useGetHasBottomSpace';
 export * from './useFieldArray';
 export * from './useTabScroll';
 export * from './useRecalculateDropdownPosition';
+export * from './useGetMenuStyles';

--- a/packages/ui-library/src/hooks/useGetMenuStyles.ts
+++ b/packages/ui-library/src/hooks/useGetMenuStyles.ts
@@ -1,0 +1,85 @@
+import { useMemo } from 'react';
+
+import { useGetElemSizes } from './useGetElemSizes';
+import { useGetElemPositions } from './useGetElemPositions';
+
+const MENU_DIRECTIONS = {
+  TOP: 'top',
+  BOTTOM: 'bottom',
+  LEFT: 'left',
+  RIGHT: 'right',
+} as const;
+
+const MENU_CORNER_POSITIONS = [
+  `${MENU_DIRECTIONS.TOP}-${MENU_DIRECTIONS.LEFT}`,
+  `${MENU_DIRECTIONS.TOP}-${MENU_DIRECTIONS.RIGHT}`,
+  `${MENU_DIRECTIONS.BOTTOM}-${MENU_DIRECTIONS.LEFT}`,
+  `${MENU_DIRECTIONS.BOTTOM}-${MENU_DIRECTIONS.RIGHT}`,
+] as const;
+
+export type TMenuCornerPosition = (typeof MENU_CORNER_POSITIONS)[number];
+
+const GAP = 4;
+const EDGE_BUFFER = 8;
+
+const isCornerPosition = (value?: string): value is TMenuCornerPosition =>
+  !!value && MENU_CORNER_POSITIONS.includes(value as TMenuCornerPosition);
+
+const getPreferredPosition = (
+  triggerLeft: number,
+  triggerTop: number,
+  windowWidth: number,
+  windowHeight: number
+): TMenuCornerPosition => {
+  const vertical = triggerTop > windowHeight / 2 ? MENU_DIRECTIONS.TOP : MENU_DIRECTIONS.BOTTOM;
+  const horizontal = triggerLeft > windowWidth / 2 ? MENU_DIRECTIONS.LEFT : MENU_DIRECTIONS.RIGHT;
+  return `${vertical}-${horizontal}`;
+};
+
+type TMenuStyles = {
+  top: number;
+  left: number;
+};
+
+export const useGetMenuStyles = (
+  parentRef: HTMLElement | null,
+  menuRef: HTMLElement | null,
+  position?: string
+): TMenuStyles => {
+  const { left, top, right, bottom } = useGetElemPositions(parentRef);
+  const { width: menuWidth, height: menuHeight } = useGetElemSizes(menuRef);
+
+  return useMemo(() => {
+    const windowWidth = typeof window !== 'undefined' ? window.innerWidth : 0;
+    const windowHeight = typeof window !== 'undefined' ? window.innerHeight : 0;
+
+    const preferredPosition = isCornerPosition(position)
+      ? position
+      : getPreferredPosition(left, top, windowWidth, windowHeight);
+    const [preferredVertical, preferredHorizontal] = preferredPosition.split('-');
+
+    const hasTopSpace = menuHeight + EDGE_BUFFER < top;
+    const hasBottomSpace = menuHeight + EDGE_BUFFER < windowHeight - bottom;
+    const hasSpaceToGrowRight = menuWidth + EDGE_BUFFER < windowWidth - left;
+    const hasSpaceToGrowLeft = menuWidth + EDGE_BUFFER < right;
+
+    let vertical = preferredVertical;
+    if (vertical === MENU_DIRECTIONS.BOTTOM && !hasBottomSpace && hasTopSpace) {
+      vertical = MENU_DIRECTIONS.TOP;
+    } else if (vertical === MENU_DIRECTIONS.TOP && !hasTopSpace && hasBottomSpace) {
+      vertical = MENU_DIRECTIONS.BOTTOM;
+    }
+
+    let horizontal = preferredHorizontal;
+    if (horizontal === MENU_DIRECTIONS.LEFT && !hasSpaceToGrowLeft && hasSpaceToGrowRight) {
+      horizontal = MENU_DIRECTIONS.RIGHT;
+    } else if (horizontal === MENU_DIRECTIONS.RIGHT && !hasSpaceToGrowRight && hasSpaceToGrowLeft) {
+      horizontal = MENU_DIRECTIONS.LEFT;
+    }
+
+    return {
+      top: vertical === MENU_DIRECTIONS.TOP ? top - menuHeight - GAP : bottom + GAP,
+      left: horizontal === MENU_DIRECTIONS.LEFT ? right - menuWidth : left + GAP,
+    };
+  }, [left, top, right, bottom, position, menuWidth, menuHeight]);
+};


### PR DESCRIPTION
Fix menu corner placement behavior and improves maintainability of menu positioning logic.

- Extracts menu placement calculations from Menu.tsx into a dedicated useGetMenuStyles hook.
- Fix incorrect horizontal mapping for menu corner positions where left/right options opened on the opposite side in Storybook and real usage.

https://github.com/user-attachments/assets/ada63fbf-6e42-4a41-8c4b-be55d041c36a

