### PR TITLE
fix: side navigation expand button

### DIFF
--- a/packages/storybook/src/stories/SideNavigation.stories.tsx
+++ b/packages/storybook/src/stories/SideNavigation.stories.tsx
@@ -193,6 +193,7 @@ const Template: StoryFn<TSideNavigationPropTypes> = args => {
                 type={NavigationItemTypes.MAIN}
                 isOpen={isNavigationItemOpen}
                 expandable
+                expandIconPosition={'left'}
                 actionsList={[{ iconProps: IconMore }]}
               >
                 <>

--- a/packages/storybook/src/stories/SideNavigation.stories.tsx
+++ b/packages/storybook/src/stories/SideNavigation.stories.tsx
@@ -13,7 +13,10 @@ import IconLockClosed from '@ab.uitools/ui-library/components/SVGIcons/IconLockC
 import IconHome from '@ab.uitools/ui-library/components/SVGIcons/IconHome';
 import IconDocumentFilled from '@ab.uitools/ui-library/components/SVGIcons/IconDocumentFilled';
 import IconDocument from '@ab.uitools/ui-library/components/SVGIcons/IconDocument';
-import { NavigationItemTypes } from '@ab.uitools/ui-library/components/SideNavigation/NavigationItem/types';
+import {
+  ExpandIconPosition,
+  NavigationItemTypes,
+} from '@ab.uitools/ui-library/components/SideNavigation/NavigationItem/types';
 import { Block } from '@ab.uitools/ui-library/components/SideNavigation/Block';
 import { NavigationItem, SideNavigation as _SideNavigation } from '@ab.uitools/ui-library/components/SideNavigation';
 import { ButtonIcon } from '@ab.uitools/ui-library/components/ButtonIcon';
@@ -193,7 +196,7 @@ const Template: StoryFn<TSideNavigationPropTypes> = args => {
                 type={NavigationItemTypes.MAIN}
                 isOpen={isNavigationItemOpen}
                 expandable
-                expandIconPosition={'left'}
+                expandIconPosition={ExpandIconPosition.LEFT}
                 actionsList={[{ iconProps: IconMore }]}
               >
                 <>

--- a/packages/ui-library/src/assets/styles/components/_side-navigation.scss
+++ b/packages/ui-library/src/assets/styles/components/_side-navigation.scss
@@ -40,6 +40,14 @@
     box-shadow: none;
   }
 
+  @media (min-width: 1025px) {
+    &:not(#{$this}--pin):not(#{$this}--opened) {
+      .navigation-item__actions__expand_mobile:not(.navigation-item__actions__expand_mobile--left) {
+        display: none;
+      }
+    }
+  }
+
   &--opened {
     width: 280px;
     min-width: 280px;
@@ -114,6 +122,23 @@
     margin-bottom: var(--ds-space-2);
   }
 
+  &--expandable > #{$this}__inner {
+    cursor: pointer;
+  }
+
+  &--expand-left {
+    > #{$this}__inner {
+      > a > .svg-icon:first-child,
+      > div:not(#{$this}__right-content, #{$this}__actions) > .svg-icon:first-child {
+        transition: opacity 0.2s linear;
+
+        @media (max-width: 1024px) {
+          opacity: 0;
+        }
+      }
+    }
+  }
+
   &__inner {
       @include mixin.flexbox;
       @include mixin.align-items(center);
@@ -156,19 +181,11 @@
       @media (min-width: 1025px) {
         &:hover {
           background-color: var(--ds-color-bg-container-light);
-
-          #{$this}__actions {
-            @include mixin.flexbox;
-          }
         }
       }
 
       @media (max-width: 1024px) {
         background-color: var(--ds-color-bg-container-light);
-
-        #{$this}__actions {
-          @include mixin.flexbox;
-        }
       }
 
       &.active {
@@ -188,20 +205,6 @@
       }
   }
 
-  &--expandable {
-    > #{$this}__inner {
-      @media (min-width: 1025px) {
-        &:hover {
-          > a, > div:not(.navigation-item__right-content, .navigation-item__actions) {
-            > .svg-icon {
-              opacity: 0;
-            }
-          }
-        }
-      }
-    }
-  }
-
   &__child {
     overflow: hidden;
     max-height: 0;
@@ -219,10 +222,11 @@
     @include mixin.justify-content(space-between);
     gap: var(--ds-space-8);
     position: absolute;
-    display: none;
+    z-index: 1;
+    pointer-events: none;
+    @include mixin.flexbox;
     padding: 0 var(--ds-space-8);
 
-    &__expand,
     &__expand_mobile {
       width: 20px;
 
@@ -241,19 +245,22 @@
       }
     }
 
-    &__expand {
-      @media (max-width: 1024px) {
-        display: none;
-      }
+    &__expand_mobile {
+      @include mixin.flexbox;
+      @include mixin.align-items(center);
+      margin-left: auto;
+      gap: var(--ds-space-8);
     }
 
-    &__expand_mobile {
-      display: none;
-      @media (max-width: 1024px) {
-        @include mixin.flexbox;
-        @include mixin.align-items(center);
-        margin-left: auto;
-        gap: var(--ds-space-8);
+    &__expand_mobile--left {
+      margin-left: 0;
+      margin-right: auto;
+      padding-left: var(--ds-space-6);
+      pointer-events: none;
+
+      @media (min-width: 1025px) {
+        opacity: 0;
+        transition: opacity 0.2s linear;
       }
     }
 
@@ -262,6 +269,28 @@
       @include mixin.align-items(center);
       margin-left: auto;
       gap: var(--ds-space-8);
+      pointer-events: auto;
+    }
+
+    &__action {
+      @media (min-width: 1025px) {
+        opacity: 0;
+        transition: opacity 0.2s linear;
+      }
+    }
+  }
+
+  @media (min-width: 1025px) {
+    &:hover > #{$this}__inner #{$this}__actions__action,
+    &:hover > #{$this}__inner #{$this}__actions__expand_mobile--left {
+      opacity: 1;
+    }
+
+    &--expand-left:hover > #{$this}__inner {
+      > a > .svg-icon:first-child,
+      > div:not(#{$this}__right-content, #{$this}__actions) > .svg-icon:first-child {
+        opacity: 0;
+      }
     }
   }
 

--- a/packages/ui-library/src/components/SideNavigation/NavigationItem/index.tsx
+++ b/packages/ui-library/src/components/SideNavigation/NavigationItem/index.tsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 import type { TActionItemProps, TNavigationLinkPropTypes } from './types';
 
-import { NavigationItemTypes } from './types';
+import { ExpandIconPosition, NavigationItemTypes } from './types';
 import IconChevronDown from '../../SVGIcons/IconChevronDown';
 import { ButtonIcon } from '../../ButtonIcon';
 import IconDynamicComponent from '../../../helperComponents/IconDynamicComponent/IconDynamicComponent';
@@ -24,7 +24,7 @@ export const NavigationItem = (props: TNavigationLinkPropTypes): ReactElement =>
       Component: IconChevronDown,
       size: 'medium',
     },
-    expandIconPosition = 'right',
+    expandIconPosition = ExpandIconPosition.RIGHT,
     children,
     actionsList,
     className = '',
@@ -49,7 +49,7 @@ export const NavigationItem = (props: TNavigationLinkPropTypes): ReactElement =>
           'navigation-item',
           `navigation-item--${type}`,
           `${expandable ? 'navigation-item--expandable' : ''}`,
-          expandable && expandIconPosition === 'left' && 'navigation-item--expand-left',
+          expandable && expandIconPosition === ExpandIconPosition.LEFT && 'navigation-item--expand-left',
           className
         )}
         onClick={() => setChildOpen(!childOpen)}
@@ -57,7 +57,7 @@ export const NavigationItem = (props: TNavigationLinkPropTypes): ReactElement =>
         <div className={classNames('navigation-item__inner', active && 'active')}>
           {expandable || actionsList?.length ? (
             <div className={'navigation-item__actions'}>
-              {expandable && expandIconPosition === 'left' && (
+              {expandable && expandIconPosition === ExpandIconPosition.LEFT && (
                 <span
                   className={classNames(
                     'navigation-item__actions__expand_mobile',
@@ -68,7 +68,7 @@ export const NavigationItem = (props: TNavigationLinkPropTypes): ReactElement =>
                   {expandIconProps.Component && <expandIconProps.Component size={expandIconProps.size || 'medium'} />}
                 </span>
               )}
-              {(actionsList?.length || (expandable && expandIconPosition === 'right')) && (
+              {(actionsList?.length || (expandable && expandIconPosition === ExpandIconPosition.RIGHT)) && (
                 <div className={'navigation-item__actions__right'}>
                   {actionsList?.map((item: TActionItemProps, index) => {
                     return (
@@ -84,7 +84,7 @@ export const NavigationItem = (props: TNavigationLinkPropTypes): ReactElement =>
                       </div>
                     );
                   })}
-                  {expandable && expandIconPosition === 'right' && (
+                  {expandable && expandIconPosition === ExpandIconPosition.RIGHT && (
                     <span className={classNames('navigation-item__actions__expand_mobile', childOpen && 'opened')}>
                       {expandIconProps.Component && (
                         <expandIconProps.Component size={expandIconProps.size || 'small'} className={'mr-12'} />

--- a/packages/ui-library/src/components/SideNavigation/NavigationItem/index.tsx
+++ b/packages/ui-library/src/components/SideNavigation/NavigationItem/index.tsx
@@ -24,6 +24,7 @@ export const NavigationItem = (props: TNavigationLinkPropTypes): ReactElement =>
       Component: IconChevronDown,
       size: 'medium',
     },
+    expandIconPosition = 'right',
     children,
     actionsList,
     className = '',
@@ -48,6 +49,7 @@ export const NavigationItem = (props: TNavigationLinkPropTypes): ReactElement =>
           'navigation-item',
           `navigation-item--${type}`,
           `${expandable ? 'navigation-item--expandable' : ''}`,
+          expandable && expandIconPosition === 'left' && 'navigation-item--expand-left',
           className
         )}
         onClick={() => setChildOpen(!childOpen)}
@@ -55,23 +57,34 @@ export const NavigationItem = (props: TNavigationLinkPropTypes): ReactElement =>
         <div className={classNames('navigation-item__inner', active && 'active')}>
           {expandable || actionsList?.length ? (
             <div className={'navigation-item__actions'}>
-              {expandable && (
-                <span className={classNames('navigation-item__actions__expand', childOpen && 'opened')}>
-                  {expandIconProps.Component && (
-                    <expandIconProps.Component size={expandIconProps.size || 'small'} className={'mr-12'} />
+              {expandable && expandIconPosition === 'left' && (
+                <span
+                  className={classNames(
+                    'navigation-item__actions__expand_mobile',
+                    'navigation-item__actions__expand_mobile--left',
+                    childOpen && 'opened'
                   )}
+                >
+                  {expandIconProps.Component && <expandIconProps.Component size={expandIconProps.size || 'medium'} />}
                 </span>
               )}
-              {(actionsList?.length || expandable) && (
+              {(actionsList?.length || (expandable && expandIconPosition === 'right')) && (
                 <div className={'navigation-item__actions__right'}>
                   {actionsList?.map((item: TActionItemProps, index) => {
                     return (
-                      <div key={index}>
-                        <ButtonIcon iconProps={{ Component: item.iconProps }} size={'small'} />
+                      <div key={index} className={'navigation-item__actions__action'}>
+                        <ButtonIcon
+                          iconProps={{ Component: item.iconProps }}
+                          size={'small'}
+                          onClick={event => {
+                            event.stopPropagation();
+                            item.onClick?.();
+                          }}
+                        />
                       </div>
                     );
                   })}
-                  {expandable && (
+                  {expandable && expandIconPosition === 'right' && (
                     <span className={classNames('navigation-item__actions__expand_mobile', childOpen && 'opened')}>
                       {expandIconProps.Component && (
                         <expandIconProps.Component size={expandIconProps.size || 'small'} className={'mr-12'} />

--- a/packages/ui-library/src/components/SideNavigation/NavigationItem/types.ts
+++ b/packages/ui-library/src/components/SideNavigation/NavigationItem/types.ts
@@ -18,11 +18,14 @@ export type TActionItemProps = {
   onClick?: () => void;
 };
 
-export type TExpandIconPosition = 'left' | 'right';
+export enum ExpandIconPosition {
+  LEFT = 'left',
+  RIGHT = 'right',
+}
 export interface TNavigationLinkPropTypes {
   As: () => JSX.Element;
   expandIconProps?: ISVGIconProps;
-  expandIconPosition?: TExpandIconPosition;
+  expandIconPosition?: ExpandIconPosition;
   type: NavigationItemTypes;
   isOpen: boolean;
   iconName?: string;

--- a/packages/ui-library/src/components/SideNavigation/NavigationItem/types.ts
+++ b/packages/ui-library/src/components/SideNavigation/NavigationItem/types.ts
@@ -17,9 +17,12 @@ export type TActionItemProps = {
   iconProps: TSVGIconComponent;
   onClick?: () => void;
 };
+
+export type TExpandIconPosition = 'left' | 'right';
 export interface TNavigationLinkPropTypes {
   As: () => JSX.Element;
   expandIconProps?: ISVGIconProps;
+  expandIconPosition?: TExpandIconPosition;
   type: NavigationItemTypes;
   isOpen: boolean;
   iconName?: string;


### PR DESCRIPTION
**Summary**

Improves the SideNavigation / NavigationItem behavior around row actions and the expand button, and adds a new prop to control which side the expand icon appears on.

**Changes**

- Hover-reveal row actions — right-side action buttons (actionsList) now appear only when the row is hovered on desktop, instead of always being visible. The expand button is unaffected.
- New expandIconPosition prop ('left' | 'right', default 'right') on NavigationItem:
  - 'right' — unchanged; chevron sits at the far right of the row.
  - 'left' — the chevron replaces the leading icon. On desktop it reveals on hover (leading icon fades out, chevron fades in); on mobile it's always shown.
- Unpinned collapsed state — on desktop, the right-side expand button is hidden when the sidebar is collapsed and unpinned, and shows again once the sidebar is opened (including on hover) or pinned.