### PR TITLE
Fix/react select

### DIFF
--- a/packages/storybook/src/stories/ReactSelect.stories.tsx
+++ b/packages/storybook/src/stories/ReactSelect.stories.tsx
@@ -4,6 +4,7 @@ import type { TReactSelectProps, TOption } from '@ab.uitools/ui-library/componen
 
 import React, { useState } from 'react';
 import IconInfo from '@ab.uitools/ui-library/components/SVGIcons/IconInfo';
+import { Modal as _Modal } from '@ab.uitools/ui-library/components/Modal';
 import { ReactSelect as _ReactSelect } from '@ab.uitools/ui-library';
 
 export default {
@@ -14,6 +15,14 @@ export default {
       options: ['large', 'small'],
       control: { type: 'radio' },
       defaultValue: 'large',
+    },
+    error: {
+      control: { type: 'text' },
+      description: 'Error message shown under the select',
+    },
+    hasError: {
+      control: { type: 'boolean' },
+      description: 'Applies the invalid styling to the control',
     },
   },
 };
@@ -109,6 +118,41 @@ const Template: StoryFn<TReactSelectProps> = args => {
 };
 export const ReactSelect = Template.bind({});
 
+// -----------REACT SELECT IN MODAL---------
+const InModalTemplate: StoryFn<TReactSelectProps> = args => {
+  const [isOpen, setIsOpen] = useState(true);
+  const [selectedValue, setSelectedValue] = useState<TItemValue | TItemValue[]>();
+
+  return (
+    <_Modal
+      isOpen={isOpen}
+      onClose={() => setIsOpen(false)}
+      onSubmit={() => setIsOpen(false)}
+      size="small"
+      closeIcon
+      titleProps={{ title: 'Select country', size: 'small' }}
+      subtitle="The dropdown is rendered inside the modal"
+      buttonProps={{
+        cancel: { buttonText: 'Cancel', type: 'tertiary' },
+        confirm: { buttonText: 'Save' },
+      }}
+    >
+      <_ReactSelect {...args} selectedValue={selectedValue} setSelectedValue={setSelectedValue} />
+    </_Modal>
+  );
+};
+export const ReactSelectInModal = InModalTemplate.bind({});
+ReactSelectInModal.args = {
+  isMulti: true,
+  required: true,
+  isClearable: true,
+  isSearchable: true,
+  options: GROUP_OPTIONS,
+  label: 'Select label',
+  placeholder: 'Placeholder text',
+  helperText: 'helper text',
+};
+
 ReactSelect.args = {
   isMulti: true,
   required: true,
@@ -124,6 +168,7 @@ ReactSelect.args = {
   hasError: false,
   label: 'Select label',
   placeholder: 'Placeholder text',
-  helperText: 'helper text',
+  error: 'here is error',
+  // helperText: 'helper text',
   labelAddons: <IconInfo size="xsmall" type="information-light" className="ml-4" />,
 };

--- a/packages/storybook/src/stories/ReactSelect.stories.tsx
+++ b/packages/storybook/src/stories/ReactSelect.stories.tsx
@@ -4,7 +4,6 @@ import type { TReactSelectProps, TOption } from '@ab.uitools/ui-library/componen
 
 import React, { useState } from 'react';
 import IconInfo from '@ab.uitools/ui-library/components/SVGIcons/IconInfo';
-import { Modal as _Modal } from '@ab.uitools/ui-library/components/Modal';
 import { ReactSelect as _ReactSelect } from '@ab.uitools/ui-library';
 
 export default {
@@ -118,41 +117,6 @@ const Template: StoryFn<TReactSelectProps> = args => {
 };
 export const ReactSelect = Template.bind({});
 
-// -----------REACT SELECT IN MODAL---------
-const InModalTemplate: StoryFn<TReactSelectProps> = args => {
-  const [isOpen, setIsOpen] = useState(true);
-  const [selectedValue, setSelectedValue] = useState<TItemValue | TItemValue[]>();
-
-  return (
-    <_Modal
-      isOpen={isOpen}
-      onClose={() => setIsOpen(false)}
-      onSubmit={() => setIsOpen(false)}
-      size="small"
-      closeIcon
-      titleProps={{ title: 'Select country', size: 'small' }}
-      subtitle="The dropdown is rendered inside the modal"
-      buttonProps={{
-        cancel: { buttonText: 'Cancel', type: 'tertiary' },
-        confirm: { buttonText: 'Save' },
-      }}
-    >
-      <_ReactSelect {...args} selectedValue={selectedValue} setSelectedValue={setSelectedValue} />
-    </_Modal>
-  );
-};
-export const ReactSelectInModal = InModalTemplate.bind({});
-ReactSelectInModal.args = {
-  isMulti: true,
-  required: true,
-  isClearable: true,
-  isSearchable: true,
-  options: GROUP_OPTIONS,
-  label: 'Select label',
-  placeholder: 'Placeholder text',
-  helperText: 'helper text',
-};
-
 ReactSelect.args = {
   isMulti: true,
   required: true,
@@ -169,6 +133,6 @@ ReactSelect.args = {
   label: 'Select label',
   placeholder: 'Placeholder text',
   error: 'here is error',
-  // helperText: 'helper text',
+  helperText: 'helper text',
   labelAddons: <IconInfo size="xsmall" type="information-light" className="ml-4" />,
 };

--- a/packages/ui-library/src/assets/styles/components/_react-select.scss
+++ b/packages/ui-library/src/assets/styles/components/_react-select.scss
@@ -32,6 +32,14 @@
       }
     }
 
+    &__caret {
+      transition: transform 0.2s ease;
+
+      &--open {
+        transform: rotate(180deg);
+      }
+    }
+
     &__container {
       width: 100%;
     }

--- a/packages/ui-library/src/components/ReactSelect/ReactSelect.tsx
+++ b/packages/ui-library/src/components/ReactSelect/ReactSelect.tsx
@@ -17,7 +17,7 @@ import {
   Option,
 } from './components';
 import { Text } from '../Text';
-import { Label } from '../../helperComponents';
+import { ErrorMessage, Label } from '../../helperComponents';
 
 export const ReactSelect = ({
   options = [],
@@ -42,6 +42,7 @@ export const ReactSelect = ({
   isRadio,
   isMulti,
   hasError,
+  error,
   required,
   label,
   size = 'large',
@@ -196,7 +197,7 @@ export const ReactSelect = ({
           ...customComponents,
         }}
         className={classNames(className, `react-select__${size}`, {
-          'react-select__invalid': hasError,
+          'react-select__invalid': hasError || error,
           'react-select__dropdown': !isSearchable && !isCreatable,
         })}
         classNamePrefix="react-select"
@@ -206,6 +207,7 @@ export const ReactSelect = ({
           {helperText}
         </Text>
       )}
+      {error ? <ErrorMessage className="mt-8" message={error} icon="infoFilled" dataId={dataId} /> : null}
     </div>
   );
 };

--- a/packages/ui-library/src/components/ReactSelect/components/DropdownIndicator.tsx
+++ b/packages/ui-library/src/components/ReactSelect/components/DropdownIndicator.tsx
@@ -1,16 +1,19 @@
 import { components, type DropdownIndicatorProps } from 'react-select';
 import React from 'react';
+import classNames from 'classnames';
 
 import type { TOption } from '../types';
 
-import { IconCaretUpFilled } from '../../SVGIcons/IconCaretUpFilled';
 import { IconCaretDownFilled } from '../../SVGIcons/IconCaretDownFilled';
 
 export const DropdownIndicator = (props: DropdownIndicatorProps<TOption, boolean>) => {
   const { menuIsOpen } = props.selectProps;
   return (
     <components.DropdownIndicator {...props}>
-      {menuIsOpen ? <IconCaretUpFilled size="xsmall" /> : <IconCaretDownFilled size="xsmall" />}
+      <IconCaretDownFilled
+        size="xsmall"
+        className={classNames('react-select__caret', { 'react-select__caret--open': menuIsOpen })}
+      />
     </components.DropdownIndicator>
   );
 };

--- a/packages/ui-library/src/components/ReactSelect/types.ts
+++ b/packages/ui-library/src/components/ReactSelect/types.ts
@@ -1,6 +1,6 @@
 import type { CreatableProps } from 'react-select/creatable';
 import type { Props, GroupBase, SingleValue, MultiValue, ActionMeta } from 'react-select';
-import type { JSX, ReactNode } from 'react';
+import type { JSX, ReactElement, ReactNode } from 'react';
 
 import type { TFormValue, TItemLabel, TItemValue, TOnChange } from '../../types/globalTypes';
 
@@ -46,6 +46,7 @@ export interface BaseProps extends Omit<Props<TOption, boolean, GroupBase<TOptio
   label?: string;
   required?: boolean;
   hasError?: boolean;
+  error?: string | ReactElement;
   helperText?: string;
   onChange?: TOnChange;
   value?: TFormValue;


### PR DESCRIPTION
1. Fixed a bug where clicking the dropdown caret while the menu was open would close a parent Modal. The indicator swapped between two icon components based on menuIsOpen, unmounting the exact node being clicked before the Modal's outside-click check ran, so it was misread as an outside click. Now a single icon is kept mounted and rotated via a react-select__caret--open class instead.

2. Added error prop support to ReactSelect, rendering an ErrorMessage below the control (consistent with Input) and applying the invalid style when either hasError or error is set.